### PR TITLE
feat(core): replace ElasticsearchTemplate by ElasticsearchOperations to support upcoming ElasticsearchRestTemplate as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `spring-esdata-loader` is a Java testing library to help you write integration tests for your [spring-data elasticsearch](https://spring.io/projects/spring-data-elasticsearch)-based projects, by allowing you to easily load data into Elasticsearch, using entity mappings (i.e domain classes annotated with `@Document`, `@Field`, etc) and via specific **Junit 4**'s Rules or **JUnit Jupiter**'s Extensions.
 
-The library reads all the metadata it needs from the entity classes (index name, index type, etc) , uses them to create/refresh the index on the ES server and feeds it with the data using the `ElasticsearchTemplate` present in your test application context.
+The library reads all the metadata it needs from the entity classes (index name, index type, etc) , uses them to create/refresh the index on the ES server and feeds it with the data using the `ElasticsearchOperations` present in your test application context.
 
 ## Features
 

--- a/core/src/main/java/com/github/spring/esdata/loader/core/SpringEsDataLoader.java
+++ b/core/src/main/java/com/github/spring/esdata/loader/core/SpringEsDataLoader.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.query.IndexQuery;
 import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder;
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 /**
- * Loader that use Spring Data's {@link ElasticsearchTemplate} to load data into Elasticsearch.
+ * Loader that use Spring Data's {@link ElasticsearchOperations} to load data into Elasticsearch.
  *
  * @author tinesoft
  *
@@ -27,15 +27,15 @@ public class SpringEsDataLoader implements EsDataLoader {
 	private static final Logger LOGGER = LoggerFactory.getLogger(SpringEsDataLoader.class);
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-	private final ElasticsearchTemplate esTemplate;
+	private final ElasticsearchOperations esOperations;
 
 	/**.
-	 * Data loader that use Spring's {@link ElasticsearchTemplate} to load data into Elasticsearch
-	 * @param esTemplate the {@link ElasticsearchTemplate}
+	 * Data loader that use Spring's {@link ElasticsearchOperations} to load data into Elasticsearch
+	 * @param esOperations the {@link ElasticsearchOperations}
 	 */
 	@Autowired
-	public SpringEsDataLoader(final ElasticsearchTemplate esTemplate) {
-		this.esTemplate = esTemplate;
+	public SpringEsDataLoader(final ElasticsearchOperations esOperations) {
+		this.esOperations = esOperations;
 	}
 
   /**
@@ -46,10 +46,10 @@ public class SpringEsDataLoader implements EsDataLoader {
   @Override
   public void delete(Class<?> esEntityClass) {
     LOGGER.debug("Dropping data in Index '{}'...", esEntityClass.getSimpleName());
-    this.esTemplate.deleteIndex(esEntityClass);
-    this.esTemplate.createIndex(esEntityClass);
-    this.esTemplate.putMapping(esEntityClass);
-    this.esTemplate.refresh(esEntityClass);
+    this.esOperations.deleteIndex(esEntityClass);
+    this.esOperations.createIndex(esEntityClass);
+    this.esOperations.putMapping(esEntityClass);
+    this.esOperations.refresh(esEntityClass);
 
   }
 
@@ -62,12 +62,12 @@ public class SpringEsDataLoader implements EsDataLoader {
 
 		// first recreate the index
     LOGGER.debug("Recreating Index for '{}'...", d.getEsEntityClass().getSimpleName());
-		this.esTemplate.deleteIndex(d.esEntityClass);
-		this.esTemplate.createIndex(d.esEntityClass);
-		this.esTemplate.putMapping(d.esEntityClass);
-		this.esTemplate.refresh(d.esEntityClass);
+		this.esOperations.deleteIndex(d.esEntityClass);
+		this.esOperations.createIndex(d.esEntityClass);
+		this.esOperations.putMapping(d.esEntityClass);
+		this.esOperations.refresh(d.esEntityClass);
 
-		ElasticsearchPersistentEntity<?> esEntityInfo = this.esTemplate.getPersistentEntityFor(d.esEntityClass);
+		ElasticsearchPersistentEntity<?> esEntityInfo = this.esOperations.getPersistentEntityFor(d.esEntityClass);
 
 		LOGGER.debug("Inserting data in Index of '{}'. Please wait...", d.getEsEntityClass().getSimpleName());
 
@@ -84,8 +84,8 @@ public class SpringEsDataLoader implements EsDataLoader {
 					.limit(d.nbMaxItems)//
 					.collect(Collectors.toList());
 
-			this.esTemplate.bulkIndex(indexQueries);
-			this.esTemplate.refresh(d.esEntityClass);
+			this.esOperations.bulkIndex(indexQueries);
+			this.esOperations.refresh(d.esEntityClass);
 
 			LOGGER.debug("Insertion successfully done");
 		} catch (IOException e) {

--- a/core/src/main/java/com/github/spring/esdata/loader/core/SpringUtils.java
+++ b/core/src/main/java/com/github/spring/esdata/loader/core/SpringUtils.java
@@ -3,7 +3,7 @@ package com.github.spring.esdata.loader.core;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
-import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 
 import java.util.Map;
 
@@ -44,7 +44,7 @@ public final class SpringUtils {
 	}
 
   /**
-   * Retrieve a {@link ElasticsearchTemplate} from the {@link ApplicationContext} and creates a {@link EsDataLoader} from it.
+   * Retrieve a {@link ElasticsearchOperations} from the {@link ApplicationContext} and creates a {@link EsDataLoader} from it.
    *
    * @param appContext the Spring {@link ApplicationContext}
    * @return a {@link EsDataLoader} that can insert or remove data from the underlying ES Server.
@@ -57,15 +57,15 @@ public final class SpringUtils {
 			throw new IllegalStateException("Missing 'ApplicationContext' field in class under test");
 		}
 
-		ElasticsearchTemplate esTemplate = SpringUtils.getBeanOfType(appContext, ElasticsearchTemplate.class);
+		ElasticsearchOperations esOperations = SpringUtils.getBeanOfType(appContext, ElasticsearchOperations.class);
 
-		if (esTemplate == null) {
-			LOGGER.error("No Spring's bean of type 'ElasticsearchTemplate' was found!");
+		if (esOperations == null) {
+			LOGGER.error("No Spring's bean of type 'ElasticsearchOperations' was found!");
 			throw new IllegalStateException(
-					"Missing bean of type 'ElasticsearchTemplate' in your Spring configuration");
+					"Missing bean of type 'ElasticsearchOperations' in your Spring configuration");
     }
 
-    return new SpringEsDataLoader(esTemplate);
+    return new SpringEsDataLoader(esOperations);
 	}
 
 }

--- a/demo/src/test/java/com/github/spring/esdata/loader/demo/junit/jupiter/DeleteEsDataExtensionTest.java
+++ b/demo/src/test/java/com/github/spring/esdata/loader/demo/junit/jupiter/DeleteEsDataExtensionTest.java
@@ -14,7 +14,7 @@ import org.springframework.boot.test.mock.mockito.MockReset;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -50,14 +50,14 @@ public class DeleteEsDataExtensionTest {
   public static final ElasticsearchContainer ES_CONTAINER = new ElasticsearchContainer(DemoTestPropertyValues.ES_DOCKER_IMAGE_VERSION);
 
   @SpyBean(reset = MockReset.NONE)
-  private ElasticsearchTemplate esMockTemplate;
+  private ElasticsearchOperations esMockOperations;
 
   @Test
   public void dataDeletedAtClassLevel() {
 
-    verify(this.esMockTemplate).deleteIndex(AuthorEsEntity.class);
-    verify(this.esMockTemplate).deleteIndex(BookEsEntity.class);
-    verify(this.esMockTemplate, never()).deleteIndex(LibraryEsEntity.class);//removed at method level, see below #dataDeleteedAtMethodLevel()
+    verify(this.esMockOperations).deleteIndex(AuthorEsEntity.class);
+    verify(this.esMockOperations).deleteIndex(BookEsEntity.class);
+    verify(this.esMockOperations, never()).deleteIndex(LibraryEsEntity.class);//removed at method level, see below #dataDeleteedAtMethodLevel()
   }
 
   @Test
@@ -65,9 +65,9 @@ public class DeleteEsDataExtensionTest {
   @DeleteEsData(esEntityClasses = {LibraryEsEntity.class})
   public void dataDeletedAtMethodLevel() {
 
-    verify(this.esMockTemplate).deleteIndex(AuthorEsEntity.class);//removed at class level, before all tests
-    verify(this.esMockTemplate).deleteIndex(BookEsEntity.class);//removed at class level, before all tests
-    verify(this.esMockTemplate).deleteIndex(LibraryEsEntity.class);
+    verify(this.esMockOperations).deleteIndex(AuthorEsEntity.class);//removed at class level, before all tests
+    verify(this.esMockOperations).deleteIndex(BookEsEntity.class);//removed at class level, before all tests
+    verify(this.esMockOperations).deleteIndex(LibraryEsEntity.class);
   }
 
   public static class ExposedDockerizedEsConfiguration implements ApplicationContextInitializer<ConfigurableApplicationContext> {

--- a/demo/src/test/java/com/github/spring/esdata/loader/demo/junit4/DeleteEsDataRuleTest.java
+++ b/demo/src/test/java/com/github/spring/esdata/loader/demo/junit4/DeleteEsDataRuleTest.java
@@ -19,7 +19,7 @@ import org.springframework.boot.test.mock.mockito.MockReset;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
@@ -62,14 +62,14 @@ public class DeleteEsDataRuleTest {
   public final static TestRule RUlE = RuleChain.outerRule(ES_CONTAINER).around(ES_DATA_REMOVER_RULE);
 
   @SpyBean(reset = MockReset.NONE)
-  private ElasticsearchTemplate esMockTemplate;
+  private ElasticsearchOperations esMockOperations;
 
   @Test
   public void dataDeletedAtClassLevel() {
 
-    verify(this.esMockTemplate).deleteIndex(AuthorEsEntity.class);
-    verify(this.esMockTemplate).deleteIndex(BookEsEntity.class);
-    verify(this.esMockTemplate, never()).deleteIndex(LibraryEsEntity.class);//removed at method level, see below #dataDeleteedAtMethodLevel()
+    verify(this.esMockOperations).deleteIndex(AuthorEsEntity.class);
+    verify(this.esMockOperations).deleteIndex(BookEsEntity.class);
+    verify(this.esMockOperations, never()).deleteIndex(LibraryEsEntity.class);//removed at method level, see below #dataDeleteedAtMethodLevel()
   }
 
   @Test
@@ -77,9 +77,9 @@ public class DeleteEsDataRuleTest {
   @DeleteEsData(esEntityClasses = {LibraryEsEntity.class})
   public void dataDeletedAtMethodLevel() {
 
-    verify(this.esMockTemplate).deleteIndex(AuthorEsEntity.class);//removed at class level, before all tests
-    verify(this.esMockTemplate).deleteIndex(BookEsEntity.class);//removed at class level, before all tests
-    verify(this.esMockTemplate).deleteIndex(LibraryEsEntity.class);
+    verify(this.esMockOperations).deleteIndex(AuthorEsEntity.class);//removed at class level, before all tests
+    verify(this.esMockOperations).deleteIndex(BookEsEntity.class);//removed at class level, before all tests
+    verify(this.esMockOperations).deleteIndex(LibraryEsEntity.class);
   }
 
   public static class ExposedDockerizedEsConfiguration implements ApplicationContextInitializer<ConfigurableApplicationContext> {

--- a/junit-jupiter/README.md
+++ b/junit-jupiter/README.md
@@ -13,7 +13,7 @@ import com.github.spring.esdata.loader.core.LoadEsData;
 import com.github.spring.esdata.loader.junit.jupiter.LoadEsDataConfig;
 import org.junit.jupiter.api.Test;
 
-//@SpringBootTest or any @ContextConfiguration(..) to initialize the Spring context that contains the ElasticsearchTemplate
+//@SpringBootTest or any @ContextConfiguration(..) to initialize the Spring context that contains the ElasticsearchOperations
 
 @LoadEsDataConfig({ // @LoadEsDataConfig is a meta annotation that is itself annotated with @ExtendWith(LoadEsDataExtension.class)
     @LoadEsData(esEntityClass=MyEsEntity1.class, location="/path/to/data1.json"),
@@ -46,7 +46,7 @@ import com.github.spring.esdata.loader.core.LoadEsData;
 import com.github.spring.esdata.loader.junit.jupiter.LoadEsDataConfig;
 import org.junit.jupiter.api.Test;
 
-//@SpringBootTest or any @ContextConfiguration(..) to initialize the Spring context that contains the ElasticsearchTemplate
+//@SpringBootTest or any @ContextConfiguration(..) to initialize the Spring context that contains the ElasticsearchOperations
 
 @DeleteEsDataConfig({ // @DeleteEsDataConfig is a meta annotation that is itself annotated with @ExtendWith(LoadEsDataExtension.class)
    MyEsEntity1.class,

--- a/junit4/README.md
+++ b/junit4/README.md
@@ -17,7 +17,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(SpringRunner.class) // required to run JUnit 4 tests with Spring magic
-//@SpringBootTest or any @ContextConfiguration(..) to initialize the Spring context that contains the ElasticsearchTemplate
+//@SpringBootTest or any @ContextConfiguration(..) to initialize the Spring context that contains the ElasticsearchOperations
 
 @LoadEsData(esEntityClass=MyEsEntity1.class, location="/path/to/data1.json")
 @LoadEsData(esEntityClass=MyEsEntity2.class, location="/path/to/data2.json")
@@ -60,7 +60,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(SpringRunner.class) // required to run JUnit 4 tests with Spring magic
-//@SpringBootTest or any @ContextConfiguration(..) to initialize the Spring context that contains the ElasticsearchTemplate
+//@SpringBootTest or any @ContextConfiguration(..) to initialize the Spring context that contains the ElasticsearchOperations
 
 @DeleteEsData({MyEsEntity1.class, MyEsEntity2.class})
 public class MyJunit4TestClass{


### PR DESCRIPTION
Hello there !
First of all, thanks for this awesome lib 👍  
I just wanted to add a PR to prepare the next release of **Spring Data ES 3.2.x**, included in the **SpringBoot 2.2.x** release, which add the usage of the high level client with the `ElasticsearchRestTemplate` bean. Given the ES TransportClient will be deprecated in favor of this new high level client, I just replace the usage of `ElasticsearchTemplate` by `ElasticsearchOperations` to be compliant with both `ElasticsearchTemplate` and `ElasticsearchRestTemplate` (cause the `ElasticsearchRestTemplate` implements the `ElasticsearchOperations` interface).
What do you think about that @tinesoft ?
Thank you